### PR TITLE
calc example exits cleanly on end of input

### DIFF
--- a/examples/calc.rb
+++ b/examples/calc.rb
@@ -28,8 +28,10 @@ loop do
   begin
     puts
     print "> "
-    puts Calculator.parse!(gets)
+    break unless (s = gets)
+    puts Calculator.parse!(s)
   rescue Rattler::Runtime::SyntaxError => e
     puts e
   end
 end
+puts


### PR DESCRIPTION
In Linux, when running the calc example, end-of-input (control-d) leaves a minor mess:

```
wayne@mercury:~/lab/rattler/gem$ examples/calc.rb

> 1 + 2
3.0

> /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/parser.rb:35:in `initialize': no implicit conversion of nil into String (TypeError)
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/parser.rb:35:in `new'
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/parser.rb:35:in `initialize'
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/recursive_descent_parser.rb:25:in `initialize'
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/packrat_parser.rb:16:in `initialize'
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/extended_packrat_parser.rb:16:in `initialize'
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/parser.rb:15:in `new'
        from /home/wayne/.rvm/gems/ruby-2.1.1/gems/rattler-0.6.0/lib/rattler/runtime/parser.rb:15:in `parse!'
        from examples/calc.rb:31:in `block in <main>'
        from examples/calc.rb:27:in `loop'
        from examples/calc.rb:27:in `<main>'
```

This just cleans that up:

```
wayne@mercury:~/lab/rattler/gem$ examples/calc.rb

> 1 + 2
3.0

> 
wayne@mercury:~/lab/rattler/gem$ 
```

Nothing Earth shattering.  Just a little cosmetic adjustment.
