### PR TITLE
Fix rtlr crash when no "grammar" declaration

### DIFF
--- a/lib/rattler/util/node.rb
+++ b/lib/rattler/util/node.rb
@@ -70,7 +70,7 @@ module Rattler::Util
     #
     # @return the node's name
     def name
-      attrs.fetch(:name, self.class.name)
+      attrs[:name] || self.class.name
     end
 
     # Call _block_ once for each child, passing that child as an argument.

--- a/spec/rattler/util/node_spec.rb
+++ b/spec/rattler/util/node_spec.rb
@@ -117,7 +117,7 @@ describe Node do
   end
 
   describe '#name' do
-    context 'when the Node as a name attribute' do
+    context 'when the Node has a name attribute' do
 
       subject { Node.new(:name => 'foo' ) }
 
@@ -129,6 +129,15 @@ describe Node do
     context 'when the Node has no name attribute' do
 
       subject { Node.new }
+
+      it 'uses the class name as name' do
+        subject.name.should == 'Rattler::Util::Node'
+      end
+    end
+
+    context 'when the Node has a nil name attribute' do
+
+      subject { Node.new(:name => nil) }
 
       it 'uses the class name as name' do
         subject.name.should == 'Rattler::Util::Node'


### PR DESCRIPTION
When given a grammar which lacks the optional "grammar" declaration, ratlr crashes with "undefined method split for nil".  This is due to the node name being set to nil when the Grammar node is created.  This patch causes a nil node name to be treated the same as a missing node name.
