### PR TITLE
%no-whitepsace directive

### DIFF
--- a/features/extended_matching_syntax/no_whitespace.feature
+++ b/features/extended_matching_syntax/no_whitespace.feature
@@ -1,0 +1,31 @@
+Feature: Cancel Whitespace Skipping
+  
+  The "%no-whitespace" directive cancels a "%whitespace" directive.
+  As with the "%whitespace" directive, "%no-whitespace" can be
+  optionally followed by a block delimited by curly braces to limit
+  whitespace cancellation to rules inside the block.
+  
+  Scenario: Block form
+    Given a grammar with:
+      """
+      %whitespace SPACE*
+      %no-whitespace {
+        word <- @WORD+
+      }
+      """
+    When I parse "  foo"
+    Then the parse result should be FAIL
+    When I parse "foo"
+    Then the parse result should be "foo"
+  
+  Scenario: Global form
+    Given a grammar with:
+      """
+      %whitespace SPACE*
+      %no-whitespace
+      word <- @WORD+
+      """
+    When I parse "  foo"
+    Then the parse result should be FAIL
+    When I parse "foo"
+    Then the parse result should be "foo"

--- a/lib/rattler/compiler/metagrammar.rb
+++ b/lib/rattler/compiler/metagrammar.rb
@@ -249,6 +249,7 @@ module Rattler
       # @private
       def match_directive! #:nodoc:
         match_ws_directive ||
+        match_no_ws_directive ||
         match_wc_directive ||
         match_inline_directive ||
         match_fragments ||
@@ -287,6 +288,37 @@ module Rattler
       end
       
       # @private
+      def match_no_ws_directive #:nodoc:
+        apply :match_no_ws_directive!
+      end
+      
+      # @private
+      def match_no_ws_directive! #:nodoc:
+        begin
+          p0 = @scanner.pos
+          begin
+            (r0_0 = match_no_ws_decl) &&
+            @scanner.skip(/(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)(?>\{)/) &&
+            (start_ws nil)
+          end || begin
+            @scanner.pos = p0
+            false
+          end
+        end ||
+        begin
+          p0 = @scanner.pos
+          begin
+            (r0_0 = match_no_ws_decl) &&
+            (set_ws nil)
+          end || begin
+            @scanner.pos = p0
+            false
+          end
+        end ||
+        fail { :no_ws_directive }
+      end
+      
+      # @private
       def match_ws_decl #:nodoc:
         apply :match_ws_decl!
       end
@@ -304,6 +336,17 @@ module Rattler
           end
         end ||
         fail { :ws_decl }
+      end
+      
+      # @private
+      def match_no_ws_decl #:nodoc:
+        apply :match_no_ws_decl!
+      end
+      
+      # @private
+      def match_no_ws_decl! #:nodoc:
+        (@scanner.skip(/(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)(?>%no\-whitespace)/) && true) ||
+        fail { :no_ws_decl }
       end
       
       # @private

--- a/lib/rattler/compiler/rattler.rtlr
+++ b/lib/rattler/compiler/rattler.rtlr
@@ -24,12 +24,17 @@ start_directive   <-  ~`%start` identifier                                      
 
 rules             <-  (directive / rule / block_close)*                         <RuleSet>
 
-directive         <-  ws_directive / wc_directive / inline_directive / fragments
+directive         <-  ws_directive / no_ws_directive / wc_directive / inline_directive / fragments
 
 ws_directive      <-  ws_decl ~'{'                                              { start_ws _ }
                     / ws_decl                                                   { set_ws _ }
 
+no_ws_directive   <-  no_ws_decl ~'{'                                           { start_ws nil }
+                    / no_ws_decl                                                { set_ws nil }
+
 ws_decl           <-  ~`%whitespace` unattributed
+
+no_ws_decl        <- ~'%no-whitespace'
 
 wc_directive      <-  wc_decl ~'{'                                              { start_wc _ }
                     / wc_decl                                                   { set_wc _ }


### PR DESCRIPTION
This directive cancels the %whitespace directive, either globally, or
limited to a block.  The use case is a grammar which is almost
entirely whitespace insensitive, except for a few rules.  Such a
grammar can now be:

```
%whitespace SPACE*

# many whitespace insensitive rules

%no-whitespace

# a few whitepsace sensitive rules
```

Or, alternatively:

```
%whitespace SPACE*

# many whitespace insensitive rules

%no-whitespace {
  # a whitespace sensitive rule
}

# more whitespace insensitive rules
```
