### PR TITLE
character sequence

### DIFF
--- a/features/extended_matching_syntax/char_sequence.feature
+++ b/features/extended_matching_syntax/char_sequence.feature
@@ -1,0 +1,35 @@
+Feature: Character sequence
+
+  A character sequences matches text a character at a time, exactly as
+  if each character had been specified separately in a sequence.  This
+  allows whitespace to be skipped between the characters of a literal,
+  provided that a %whitespace directive is in effect.
+
+  A character sequence is written like `%c"..."` or %c'...'`.  The "c"
+  stands for "characters."
+
+  The character sequence:
+
+      %c"THEN"
+
+  is equivalent to
+
+      ("T" "H" "E" "N")
+
+  Most of the time, you probably want a string literal.  Character
+  sequence exists for strange languages like BASIC and Fortran, which
+  permit whitespace in keywords.
+  
+  Scenario Outline: Normal String
+    Given a grammar with:
+      """
+      %whitespace SPACE*
+      a <- %c"IF"
+      """
+    When I parse <input>
+    Then the parse result should be <result>
+  
+  Examples:
+    | input  |   result   |
+    | "IF"   | ["I", "F"] |
+    | " I F" | ["I", "F"] |

--- a/features/extended_matching_syntax/char_sequence.feature
+++ b/features/extended_matching_syntax/char_sequence.feature
@@ -5,8 +5,8 @@ Feature: Character sequence
   allows whitespace to be skipped between the characters of a literal,
   provided that a %whitespace directive is in effect.
 
-  A character sequence is written like `%c"..."` or %c'...'`.  The "c"
-  stands for "characters."
+  A character sequence is written like `%c"..."` or `%c'...'`.  The
+  "c" stands for "characters."
 
   The character sequence:
 

--- a/lib/rattler/compiler/grammar_parser.rb
+++ b/lib/rattler/compiler/grammar_parser.rb
@@ -119,6 +119,13 @@ module Rattler::Compiler
       Token[Sequence[literal("%q#{e}"), Disallow[@wc]]]
     end
 
+    def char_sequence(e)
+      literals = e.chars.map do |char|
+        literal(char.inspect)
+      end
+      Sequence[literals]
+    end
+
     def char_class(e)
       Match[Regexp.compile(e)]
     end

--- a/lib/rattler/compiler/metagrammar.rb
+++ b/lib/rattler/compiler/metagrammar.rb
@@ -1285,8 +1285,47 @@ module Rattler
             false
           end
         end ||
+        match_molecule ||
         match_atom ||
         fail! { :primary }
+      end
+      
+      # @private
+      def match_molecule #:nodoc:
+        apply :match_molecule!
+      end
+      
+      # @private
+      def match_molecule! #:nodoc:
+        begin
+          p0 = @scanner.pos
+          begin
+            (r0_0 = match_char_sequence) &&
+            (char_sequence r0_0)
+          end || begin
+            @scanner.pos = p0
+            false
+          end
+        end ||
+        fail { :molecule }
+      end
+      
+      # @private
+      def match_char_sequence #:nodoc:
+        apply :match_char_sequence!
+      end
+      
+      # @private
+      def match_char_sequence! #:nodoc:
+        begin
+          @scanner.skip(/(?>(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)(?>%c"))(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)((?>(?>\\)(?>.)|[^"])*)(?>(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)(?>"))/) &&
+          @scanner[1]
+        end ||
+        begin
+          @scanner.skip(/(?>(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)(?>%c'))(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)((?>(?>\\)(?>.)|[^'])*)(?>(?>(?>(?>[[:space:]])+|(?>\#)(?>(?>[^\n])*))*)(?>'))/) &&
+          @scanner[1]
+        end ||
+        fail { :char_sequence }
       end
       
       # @private

--- a/lib/rattler/compiler/rattler.rtlr
+++ b/lib/rattler/compiler/rattler.rtlr
@@ -112,7 +112,13 @@ suffixable        <-  suffixed / primary
                     / expected 'primary'
 
 primary           <-  ~'(' expression ~')'
+                    / molecule
                     / atom
+
+molecule          <- char_sequence                                              { char_sequence _ }
+
+char_sequence     <-  (~'%c"' @('\\' . / [^"])* ~'"')
+                    / (~"%c'" @('\\' . / [^'])* ~"'")
 
 atom              <-  ~`EOF`                                                    <Eof>
                     / ~`E`                                                      <ESymbol>


### PR DESCRIPTION
A character sequences matches text a character at a time, exactly as
if each character had been specified separately in a sequence.  This
allows whitespace to be skipped between the characters of a literal,
provided that a %whitespace directive is in effect.

A character sequence is written like `%c"..."` or `%c'...'`.  The "c"
stands for "characters."

The character sequence:

```
%c"THEN"
```

is equivalent to

```
("T" "H" "E" "N")
```

Most of the time, you probably want a string literal.  Character
sequence exists for strange languages like BASIC and Fortran, which
permit whitespace in keywords.
