### PR TITLE
Warn about textual substitution of labels in normal semantic nodes

### DIFF
--- a/features/semantics/labels.feature
+++ b/features/semantics/labels.feature
@@ -4,6 +4,10 @@ Feature: Labels
   before an expression. Labels are meaningful in actions: they can be used as
   identifiers in normal semantic actions, and in node actions the mappings are
   passed as a :labeled attribute.
+
+  Labels in normal semantic actions are implemented by _textual
+  substitution_: any instance of that label in the semantic action is
+  replaced with the label's value, without regard to Ruby syntax.
   
   Scenario: Normal symantic action
     Given a grammar with:

--- a/features/semantics/labels.feature
+++ b/features/semantics/labels.feature
@@ -2,7 +2,7 @@ Feature: Labels
   
   Labels can be attached to parse results by putting a name followed by ":"
   before an expression. Labels are meaningful in actions: they can be used as
-  identifiers in normal symantic actions, and in node actions the mappings are
+  identifiers in normal semantic actions, and in node actions the mappings are
   passed as a :labeled attribute.
   
   Scenario: Normal symantic action


### PR DESCRIPTION
This is a warning for something that just bit me:

```
exponent_edit_descriptor <- letter:[ED] width:unsigned_integer
                            "." fractional_digits:unsigned_integer
                            exponent_digits:( ~"E" unsigned_integer )?
{
  exponent_digits = exponent_digits.first || :default
  ExponentEditDescriptor.new(
    width,
    fractional_digits,
    exponent_digits: exponent_digits,
    letter: letter
  )
}
```

After substitution, the semantic rule became:

```
exponent_edit_descriptor <- letter:[ED] width:unsigned_integer
                            "." fractional_digits:unsigned_integer
                            exponent_digits:( ~"E" unsigned_integer )?
{
  exponent_digits = exponent_digits.first || :default
  ExponentEditDescriptor.new(
    width,
    fractional_digits,
    r0_4: r0_4,
    r0_0: r0_0
  )
}
```

with the error message "unknown keywords: r0_4, r0_0".  Confusion resulted.
